### PR TITLE
fix(ci): Un-stuck CI/CD via GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,16 @@
 name: CI
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches:
+      - main
+      - master
+    tags:
+      - '*'
+  pull_request:
+    branches:
+      - main
+      - master
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,21 +1,11 @@
 name: CI
 
-on:
-  push:
-    branches:
-      - main
-      - master
-    tags:
-      - '*'
-  pull_request:
-    branches:
-      - main
-      - master
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
     name: "Build"
-    runs-on: package
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
@@ -38,7 +28,7 @@ jobs:
       - name: Upload build archive for test runners
         uses: actions/upload-artifact@v4
         with:
-          name: package
+          name: ${{ runner.os }}
           path: /tmp/package
 
   tag:

--- a/sourceknight.yaml
+++ b/sourceknight.yaml
@@ -10,6 +10,13 @@ project:
       - source: /addons
         dest: /addons
 
+    - name: eventqueue
+      type: git
+      repo: https://github.com/srcdslab/sm-ext-eventqueue
+      unpack:
+      - source: /include
+        dest: /addons/sourcemod/scripting/include
+
     - name: vscripts
       type: git
       repo: https://github.com/srcdslab/sm-plugin-VScript

--- a/sourceknight.yaml
+++ b/sourceknight.yaml
@@ -14,7 +14,7 @@ project:
       type: git
       repo: https://github.com/srcdslab/sm-ext-eventqueue
       unpack:
-      - source: /include
+      - source: /package/addons/sourcemod/scripting/include
         dest: /addons/sourcemod/scripting/include
 
     - name: vscripts


### PR DESCRIPTION
This PR solve these 2 issues:
1. `This request was automatically failed because there were no enabled runners online to process the request for more than 1 days.`
2. `/github/workspace/.sourceknight/build/addons/sourcemod/scripting/include/vscripts.inc(10) : error 417: cannot read from file: "eventqueue"`